### PR TITLE
Fix #2 + ZeroMQ version v4.2.2

### DIFF
--- a/v140/libzmq-4.2.0-ia32.lib
+++ b/v140/libzmq-4.2.0-ia32.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d29c87a1511921382a179a6c55627b62dabf988a3b8c543509d79dccbf42398e
-size 9537462
+oid sha256:df7cfe160e45dedf3cc6b0868bf620b08f48a4835bcc90785ba57c60b3eb7487
+size 9886590

--- a/v140/libzmq-4.2.0-x64.lib
+++ b/v140/libzmq-4.2.0-x64.lib
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6e5f492e68e7eb141b7e43fc841a7c50b022b4348e59e3589cc3e78b32ca1142
-size 10995482
+oid sha256:73ca7fcf1955856c68d07c704867e9bf7b0b38d3a5cd779de492e5bc84105ed2
+size 11355062

--- a/v140/libzmq-4.2.2-ia32.lib
+++ b/v140/libzmq-4.2.2-ia32.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38e193fe724f367077345c2e2ba53a53db01261233920bb6be8652bc462e2d88
+size 9899508

--- a/v140/libzmq-4.2.2-x64.lib
+++ b/v140/libzmq-4.2.2-x64.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:093bfd0643fd053c919a5040dba1a69c36a40dbfc74c209f4d62522b295a3cb1
+size 11367364


### PR DESCRIPTION
1. Fixed issue #2 (version 4.2.0 missing TweetNacl option)
2. Compilation of static libraries for release [v4.2.2](https://github.com/zeromq/libzmq/releases/tag/v4.2.2).

In both cases:
- Visual Studio 2015
- Solution's configuration: _StaticRelease_
- Solution's platform: _Win32_ and _x64_
- ZMQ option _TweetNacl_ enabled.