### PR TITLE
Add libzmq-4.2.2 with tweetnacl

### DIFF
--- a/v140/libzmq-4.2.2-ia32.lib
+++ b/v140/libzmq-4.2.2-ia32.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d20a0478091164ea7bd13310e128eb58813b7ed6bd914617a540e6a366e0a534
+size 9932420

--- a/v140/libzmq-4.2.2-x64.lib
+++ b/v140/libzmq-4.2.2-x64.lib
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd2081667add95908b0371547dd275a846589af777168cb31192d0f973bf7a11
+size 11400446


### PR DESCRIPTION
Big thanks to @vtellier!

This adds libs compiled with TweetNacl.

Compilation of static libraries for release v4.2.2.

- Visual Studio 2015
- Solution's configuration: StaticRelease
- Solution's platform: Win32 and x64
- ZMQ option TweetNacl enabled.